### PR TITLE
Dasherize keys

### DIFF
--- a/backend/app/serializers/base_serializer.rb
+++ b/backend/app/serializers/base_serializer.rb
@@ -1,0 +1,9 @@
+class BaseSerializer < ActiveModel::Serializer
+  def attributes *options
+    attrs = super
+
+    Hash[attrs.map do |key, value|
+      [key.to_s.dasherize.to_sym, value]
+    end]
+  end
+end

--- a/backend/app/serializers/machine_serializer.rb
+++ b/backend/app/serializers/machine_serializer.rb
@@ -1,3 +1,3 @@
-class MachineSerializer < ActiveModel::Serializer
+class MachineSerializer < BaseSerializer
   attributes :id, :name, :status, :disk_usage, :tag_list
 end

--- a/backend/app/serializers/runscript_serializer.rb
+++ b/backend/app/serializers/runscript_serializer.rb
@@ -1,3 +1,3 @@
-class RunscriptSerializer < ActiveModel::Serializer
+class RunscriptSerializer < BaseSerializer
   attributes :id, :name, :script, :tag_list
 end

--- a/backend/test/serializers/machine_serializer_test.rb
+++ b/backend/test/serializers/machine_serializer_test.rb
@@ -16,8 +16,8 @@ class MachineSerializerTest < ActiveSupport::TestCase
         attributes: {
           name: machine.name,
           status: machine.status,
-          disk_usage: machine.disk_usage,
-          tag_list: ["store", "pear"]
+          "disk-usage": machine.disk_usage,
+          "tag-list": ["store", "pear"]
         }
       }
     }

--- a/backend/test/serializers/runscript_serializer_test.rb
+++ b/backend/test/serializers/runscript_serializer_test.rb
@@ -17,7 +17,7 @@ class RunscriptSerializerTest < ActiveSupport::TestCase
         attributes: {
           name: runscript.name,
           script: runscript.script,
-          tag_list: ["store", "banana"]
+          "tag-list": ["store", "banana"]
         }
       }
     }


### PR DESCRIPTION
ams/jsonapi doesn't transform the keys, and ember-data/jsonapi requires the keys to be dasherized.
I've defined a base serializer that automatically dasherizes all keys.
